### PR TITLE
Branch edit command bug fixes

### DIFF
--- a/src/main/java/command/EditCommand.java
+++ b/src/main/java/command/EditCommand.java
@@ -79,8 +79,8 @@ public class EditCommand extends Command {
         try {
             switch (commandType) {
             case AssignmentCommand.COMMAND_WORD:
-                if (taskList.getTask(editIndex) instanceof RepeatEvent ||
-                        taskList.getTask(editIndex) instanceof Event) {
+                if (taskList.getTask(editIndex) instanceof RepeatEvent
+                        || taskList.getTask(editIndex) instanceof Event) {
                     return new CommandResult(Messages.EDIT_TYPE_ERROR);
                 }
 

--- a/src/main/java/command/EditCommand.java
+++ b/src/main/java/command/EditCommand.java
@@ -80,7 +80,7 @@ public class EditCommand extends Command {
             switch (commandType) {
             case AssignmentCommand.COMMAND_WORD:
                 Task editedAssignment = editAssignment(userInput, ui);
-                if (taskList.isSameTask(taskList, editedAssignment)) {
+                if (taskList.isSameEdit(taskList, editedAssignment, editIndex)) {
                     return new CommandResult(Messages.SAME_TASK_ERROR);
                 }
 
@@ -88,7 +88,7 @@ public class EditCommand extends Command {
                 return new CommandResult(String.format(Messages.EDIT_SUCCESS_MESSAGE, editedAssignment));
             case EventCommand.COMMAND_WORD:
                 Event editedEvent = editEvent(userInput, ui);
-                if (taskList.isSameTask(taskList, editedEvent)) {
+                if (taskList.isSameEdit(taskList, editedEvent, editIndex)) {
                     return new CommandResult((Messages.SAME_TASK_ERROR));
                 }
                 //Check if Event to be edited is repeating event.

--- a/src/main/java/command/EditCommand.java
+++ b/src/main/java/command/EditCommand.java
@@ -56,7 +56,7 @@ public class EditCommand extends Command {
     /**
      * Executes the edit command function.
      * Takes in a new input from the user and formats input.
-     * Replaces task from the tasklist at index specified by user.
+     * Replaces task from the taskList at index specified by user.
      * @param taskList TaskList object that handles adding Task
      * @param ui Ui object that interacts with user
      * @return CommandResult object based on result
@@ -79,7 +79,13 @@ public class EditCommand extends Command {
         try {
             switch (commandType) {
             case AssignmentCommand.COMMAND_WORD:
+                if (taskList.getTask(editIndex) instanceof RepeatEvent ||
+                        taskList.getTask(editIndex) instanceof Event) {
+                    return new CommandResult(Messages.EDIT_TYPE_ERROR);
+                }
+
                 Task editedAssignment = editAssignment(userInput, ui);
+
                 if (taskList.isSameEdit(taskList, editedAssignment, editIndex)) {
                     return new CommandResult(Messages.SAME_TASK_ERROR);
                 }
@@ -87,6 +93,10 @@ public class EditCommand extends Command {
                 taskList.editTask(editIndex, editedAssignment);
                 return new CommandResult(String.format(Messages.EDIT_SUCCESS_MESSAGE, editedAssignment));
             case EventCommand.COMMAND_WORD:
+                if (taskList.getTask(editIndex) instanceof Assignment) {
+                    return new CommandResult(Messages.EDIT_TYPE_ERROR);
+                }
+
                 Event editedEvent = editEvent(userInput, ui);
                 if (taskList.isSameEdit(taskList, editedEvent, editIndex)) {
                     return new CommandResult((Messages.SAME_TASK_ERROR));

--- a/src/main/java/common/Messages.java
+++ b/src/main/java/common/Messages.java
@@ -51,7 +51,7 @@ public class Messages {
             + System.lineSeparator() + NEWLINE_INDENT + "%s.";
     public static final String REPEATING_SUCCESS_MESSAGE = "[%s] will repeat every %s%s%s.";
     public static final String STOP_REPEATING_SUCCESS_MESSAGE = "[%s] will no longer repeat.";
-    public static final String EDIT_PROMPT = "Please edit your chosen task.";
+    public static final String EDIT_PROMPT = "Please edit your chosen task. Task Type needs to remain the same.";
 
     // Common Error Messages
     public static final String INCORRECT_COMMAND_ERROR = "Oh no. %s";

--- a/src/main/java/common/Messages.java
+++ b/src/main/java/common/Messages.java
@@ -51,7 +51,7 @@ public class Messages {
             + System.lineSeparator() + NEWLINE_INDENT + "%s.";
     public static final String REPEATING_SUCCESS_MESSAGE = "[%s] will repeat every %s%s%s.";
     public static final String STOP_REPEATING_SUCCESS_MESSAGE = "[%s] will no longer repeat.";
-    public static final String EDIT_PROMPT = "Please edit your chosen task. Task Type needs to remain the same.";
+    public static final String EDIT_PROMPT = "Please edit your chosen task.";
 
     // Common Error Messages
     public static final String INCORRECT_COMMAND_ERROR = "Oh no. %s";
@@ -83,6 +83,7 @@ public class Messages {
     public static final String EMPTY_DONE_CLEAR_ERROR = "There are no completed tasks at the moment";
     public static final String REPEAT_ASSIGN_ERROR = "%s is not an event. Please choose an event.";
     public static final String REPEAT_NOT_SET_ERROR = "%s is not set to repeat.";
+    public static final String EDIT_TYPE_ERROR = "Error: New Task Type must match edited Task Type";
     //Saving Error Messages
     public static final String INCORRECT_START_END_TIME_ERROR = "The end time should come after the start time";
     public static final String INCORRECT_STORAGE_FORMAT_ERROR = "The local save file is of an unknown format. "

--- a/src/main/java/seedu/atas/TaskList.java
+++ b/src/main/java/seedu/atas/TaskList.java
@@ -70,6 +70,24 @@ public class TaskList {
 
     //@@author jichngan
     /**
+     * Checks for duplicate tasks within tasklist that is not the current specified task.
+     * @param tasklist TaskList to be checked against
+     * @param editedTask Edited task that needs to be checked
+     * @param editIndex Checked against list index to see whether its the task to be edited
+     * @return True if there exists another task within taskList. Otherwise, false.
+     */
+    public Boolean isSameEdit(TaskList tasklist, Task editedTask, int editIndex) {
+        int index = 0;
+        for (Task task : tasklist.getTaskArray()) {
+            if (task.equals(editedTask) && index != editIndex) {
+                return true;
+            }
+            index++;
+        }
+        return false;
+    }
+
+    /**
      * Getter for the current Local Date.
      * Formats Local Date into "dd/MM/yyyy" format.
      * @return LocalDate object of the formatted current Date
@@ -82,7 +100,7 @@ public class TaskList {
         return formattedCurrDate;
     }
 
-    //@@author jichngan
+
     /**
      * Getter method for tasks depending of days from today.
      * @param days Integer representing number of days from today

--- a/src/test/java/command/EditCommandTest.java
+++ b/src/test/java/command/EditCommandTest.java
@@ -96,7 +96,7 @@ public class EditCommandTest {
             System.setOut(new PrintStream(testOutput));
 
             Ui ui = new Ui();
-            feedback = new EditCommand(0).execute(filledTaskList, ui).feedbackToUser;
+            feedback = new EditCommand(1).execute(filledTaskList, ui).feedbackToUser;
         } finally {
             System.setIn(consoleIn);
             System.setOut(consoleOut);
@@ -105,6 +105,7 @@ public class EditCommandTest {
                 + lineSeparator + Messages.PROMPT_FOR_USER_INPUT, testOutput.toString());
         assertEquals(Messages.SAME_TASK_ERROR, feedback);
     }
+
 
     @Test
     public void testEditTask_erroneousInput() {


### PR DESCRIPTION
Fix bug which did not allow user to edit the time/comments of tasks while retaining the same name of the task. Add method in tasklist to fix this bug. 
Fix bug which display success message if different task type is edited. i.e. Assignment task edited to event task. 